### PR TITLE
Fix hearth emoji

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 
             <hr>
 
-            <h2>Czech Companies that ❤ Open-Source</h2>
+            <h2>Czech Companies that ❤️️ Open-Source</h2>
 
             <div class="card-deck">
                 {% for company in site.data.companies %}


### PR DESCRIPTION
It was not sharp on retina display before. I've changed it for ❤️ emoji, but it is not so obvious in diff.. so I'm quite confused.. 